### PR TITLE
Make multiproof builder faster

### DIFF
--- a/ssz-multiproofs/Cargo.toml
+++ b/ssz-multiproofs/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 default = []
-builder = ["dep:ssz_rs", "dep:ethereum-consensus", "dep:rayon"]
+builder = ["dep:ssz_rs", "dep:ethereum-consensus", "dep:rayon", "dep:smallvec"]
 progress-bar = ["dep:indicatif"]
 
 [dependencies]
@@ -23,6 +23,7 @@ ethereum-consensus = { workspace = true, optional = true , features = ["serde"] 
 rayon = { version = "1.10.0", optional = true }
 indicatif = { version = "0.17.9", features = ["rayon"], optional = true }
 itertools = "0.14.0"
+smallvec = { version = "1.15.0", optional = true }
 
 [dev-dependencies]
 # gindices.workspace = true


### PR DESCRIPTION
This makes the multiproof builder much faster for better dev QoL. I've seen that running `native-exec` is anywhere from 1.5x to 2x faster now from 4.5 mins to ~2.5-3 mins