### PR TITLE
HarnessStateReader takes BeaconChainHarness as ref instead

### DIFF
--- a/core/test_utils/src/test_harness_state_reader.rs
+++ b/core/test_utils/src/test_harness_state_reader.rs
@@ -16,12 +16,12 @@ use z_core::{
     Version,
 };
 
-pub struct HarnessStateReader<T: BeaconChainTypes> {
-    inner: BeaconChainHarness<T>,
+pub struct HarnessStateReader<'a, T: BeaconChainTypes> {
+    inner: &'a BeaconChainHarness<T>,
     validator_cache: FrozenMap<Epoch, Vec<(ValidatorIndex, ValidatorInfo)>>,
 }
 
-impl<T> HarnessStateReader<T>
+impl<T> HarnessStateReader<'_, T>
 where
     T: BeaconChainTypes,
 {
@@ -33,11 +33,11 @@ where
     }
 }
 
-impl<T> From<BeaconChainHarness<T>> for HarnessStateReader<T>
+impl<'a, T> From<&'a BeaconChainHarness<T>> for HarnessStateReader<'a, T>
 where
     T: BeaconChainTypes,
 {
-    fn from(inner: BeaconChainHarness<T>) -> Self {
+    fn from(inner: &'a BeaconChainHarness<T>) -> Self {
         Self {
             inner,
             validator_cache: FrozenMap::new(),
@@ -57,7 +57,7 @@ impl From<beacon_chain::BeaconChainError> for HarnessStateReaderError {
     }
 }
 
-impl<T> StateReader for HarnessStateReader<T>
+impl<T> StateReader for HarnessStateReader<'_, T>
 where
     T: BeaconChainTypes,
 {
@@ -122,7 +122,7 @@ fn is_active_validator(validator: &Validator, epoch: Epoch) -> bool {
     validator.activation_epoch <= epoch && epoch < validator.exit_epoch.into()
 }
 
-impl<T> ChainReader for HarnessStateReader<T>
+impl<T> ChainReader for HarnessStateReader<'_, T>
 where
     T: BeaconChainTypes,
 {

--- a/core/tests/verify.rs
+++ b/core/tests/verify.rs
@@ -21,7 +21,7 @@ async fn test_zkasper_sync(
 ) -> ConsensusState {
     let head_state = harness.chain.head_beacon_state_cloned();
 
-    let state_reader = HarnessStateReader::from(harness);
+    let state_reader = HarnessStateReader::from(&harness);
     let mut consensus_state = initial_consensus_state;
 
     println!("Pre consensus state: {:?}", consensus_state);


### PR DESCRIPTION
This makes it possible to write one test case that calls `test_zkasper_sync` more than once