### PR TITLE
Add test case for `finalize_with_validator_activation_and_delayed_finality`

### DIFF
--- a/core/src/state_reader/ssz_state_reader.rs
+++ b/core/src/state_reader/ssz_state_reader.rs
@@ -132,6 +132,7 @@ impl StateReader for SszStateReader<'_> {
         epoch: Epoch,
     ) -> Result<impl Iterator<Item = (ValidatorIndex, &ValidatorInfo)>, Self::Error> {
         assert!(state_epoch >= epoch, "Only historical epochs supported");
+
         Ok(self
             .validators
             .iter()

--- a/core/tests/sync.rs
+++ b/core/tests/sync.rs
@@ -323,10 +323,6 @@ async fn finalize_after_inactivity_leak() {
 
     println!("Current slot: {}", head_state.slot());
 
-    // let two_thirds = (VALIDATOR_COUNT as usize / 3) * 2;
-    // let less_than_two_thirds = two_thirds - 2;
-    // let attesters = (0..less_than_two_thirds).collect();
-
     // Where we get into leak
     let target_epoch =
         harness.get_current_state().current_epoch() + spec.min_epochs_to_inactivity_penalty + 1;


### PR DESCRIPTION
Added a test case which shows how our current implementation is lacking in its ability to handle deposits

