### PR TITLE
Fix wrong earliest_exit_epoch

### DIFF
--- a/core/src/guest_gindices.rs
+++ b/core/src/guest_gindices.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Beacon block indices
+pub const fn state_root_gindex() -> u64 {
+    11u64
+}
+
+// Beacon state indices
 pub const fn slot_gindex() -> u64 {
     66u64
 }
@@ -32,4 +38,10 @@ pub const fn validators_gindex() -> u64 {
 }
 pub const fn finalized_checkpoint_epoch_gindex() -> u64 {
     168u64
+}
+pub const fn earliest_exit_epoch_gindex() -> u64 {
+    95u64
+}
+pub const fn earliest_consolidation_epoch_gindex() -> u64 {
+    97u64
 }

--- a/core/src/state_reader/preflight_state_reader.rs
+++ b/core/src/state_reader/preflight_state_reader.rs
@@ -86,6 +86,8 @@ where
                 .with_path::<ElectraBeaconState>(&["fork".into(), "epoch".into()])
                 .with_path::<ElectraBeaconState>(&["validators".into()])
                 .with_path::<ElectraBeaconState>(&["finalized_checkpoint".into(), "epoch".into()])
+                .with_path::<ElectraBeaconState>(&["earliest_exit_epoch".into()])
+                .with_path::<ElectraBeaconState>(&["earliest_consolidation_epoch".into()])
                 .build(state)
                 .unwrap(),
             _ => {
@@ -105,6 +107,7 @@ where
         proof_builder = proof_builder.with_path::<Validators>(&[PathElement::Length]);
 
         for (idx, validator) in trusted_state.validators().iter().enumerate() {
+            // if the validator is no longer active only include its exit_epoch field
             if self.trusted_checkpoint.epoch().as_u64() >= validator.exit_epoch {
                 proof_builder =
                     proof_builder.with_path::<Validators>(&[idx.into(), "exit_epoch".into()]);


### PR DESCRIPTION
Since we cannot distinguish between exits and consolidations, simply taking the maximum of all validators' exit_epoch is insufficient. Instead, we must use the values given in the Beacon state.