### PR TITLE
Use active validators from `StateReader` during preflight

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -41,7 +41,6 @@ risc0-zkvm = { workspace = true, features = ["std", "unstable", "prove"] }
 safe_arith = { workspace = true }
 serde = "1.0"
 serde_json = "1.0.133"
-serde_with = "3.13"
 ssz-multiproofs = { path = "../ssz-multiproofs", features = ["builder", "progress-bar"] }
 ssz_rs = { workspace = true, default-features = false, features = ["serde", "std"] }
 ssz_types = { version = "0.8.0" }

--- a/host/src/state_reader/host_state_reader.rs
+++ b/host/src/state_reader/host_state_reader.rs
@@ -132,7 +132,7 @@ impl<P: StateProvider> StateReader for HostStateReader<P> {
                     .validators()
                     .par_iter()
                     .enumerate()
-                    .filter(move |(_, validator)| is_active_validator(validator, epoch.into()))
+                    .filter(move |(_, validator)| is_active_validator(validator, epoch.as_u64()))
                     .map(move |(idx, validator)| (idx, to_validator_info(validator)))
                     .collect();
                 debug!("Active validators: {}", validators.len());

--- a/host/tests/sync.rs
+++ b/host/tests/sync.rs
@@ -123,7 +123,7 @@ async fn test_zkasper_sync(
                 _ = verify(cfg, &preflight_state_reader, input.clone())?;
 
                 // build a self-contained SSZ reader
-                let state_input = preflight_state_reader.to_input();
+                let state_input = preflight_state_reader.to_input().unwrap();
                 let ssz_state_reader = state_input
                     .clone()
                     .into_state_reader(


### PR DESCRIPTION
Use the (cached) active validators from the HostReader during preflight instead of decompressing the public key again.