### PR TITLE
fix: replace broken link to Signal repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Signal: Ethereum (TSEth)
 
-A ZKVM-friendly implementation of [Casper FFG](https://arxiv.org/abs/2003.03052), the finality gadget used by the Ethereum beacon chain. This forms part of [The Signal](https://github.com/boundless-xyz/signal) - an open source initiative to build trustless interoperability across all chains.
+A ZKVM-friendly implementation of [Casper FFG](https://arxiv.org/abs/2003.03052), the finality gadget used by the Ethereum beacon chain. This forms part of [The Signal](https://github.com/boundless-xyz/Signal-Ethereum) - an open source initiative to build trustless interoperability across all chains.
 
 > [!WARNING]  
 > The Signal: Ethereum is currently under audit and its design under peer review. The code, or the generated proofs should not be used in any production system. Aspects of the design may change without notice.


### PR DESCRIPTION
Replace the broken link to boundless-xyz/signal (404) with a working link to boundless-xyz/Signal-Ethereum (200), which appears to be the main repository of the project

If there's a more appropriate replacement for the original signal repository or if this repository is archived and should not be referenced, please let me know and close this PR 