### PR TITLE
Lower justification threshold to 70% on Sepolia

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -42,6 +42,16 @@ pub static DEFAULT_CONFIG: Config = Config {
     justification_threshold_quotient: 100,
 };
 
+/// Sepolia-specific configuration with a lowered justification threshold (70%
+/// vs the 85% default).
+pub static SEPOLIA_CONFIG: Config = Config {
+    min_version: ForkName::Electra,
+    max_version: ForkName::Fulu,
+    epoch_lookahead_limit: Epoch::new(4),
+    justification_threshold_factor: 70,
+    justification_threshold_quotient: 100,
+};
+
 impl Config {
     pub fn is_supported_version(&self, fork_name: ForkName) -> bool {
         self.min_version <= fork_name && fork_name <= self.max_version

--- a/host/src/bin/zkasper_cli.rs
+++ b/host/src/bin/zkasper_cli.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/host/src/bin/zkasper_cli.rs
+++ b/host/src/bin/zkasper_cli.rs
@@ -33,7 +33,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use url::Url;
 use z_core::{
     ChainSpec, Checkpoint, Config, ConsensusState, DEFAULT_CONFIG, Epoch, EthSpec, GuestInput,
-    MainnetEthSpec, Slot, abi, verify,
+    MainnetEthSpec, SEPOLIA_CONFIG, Slot, abi, verify,
 };
 
 // all chains use the mainnet preset
@@ -147,6 +147,16 @@ impl fmt::Display for Network {
     }
 }
 
+/// Returns the verification config to use for the given network. Sepolia
+/// uses a lower justification threshold to tolerate sustained dips in
+/// testnet attestation participation; mainnet uses the strict default.
+fn config_for(network: Network) -> &'static Config {
+    match network {
+        Network::Sepolia => &SEPOLIA_CONFIG,
+        Network::Mainnet => &DEFAULT_CONFIG,
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::try_parse()?;
@@ -187,6 +197,7 @@ async fn main() -> anyhow::Result<()> {
                 trusted_epoch,
                 caching_provider,
                 &beacon_client,
+                config_for(args.network),
             )
             .await?;
 
@@ -196,7 +207,7 @@ async fn main() -> anyhow::Result<()> {
                 &input_bytes,
                 args.network,
                 mode,
-                &DEFAULT_CONFIG,
+                config_for(args.network),
             )?;
             info!("Post-state: {:#?}", post_state);
         }
@@ -244,6 +255,7 @@ async fn main() -> anyhow::Result<()> {
                 finalized_epoch,
                 caching_provider.clone(),
                 &beacon_client,
+                config_for(args.network),
             )
             .await?;
 
@@ -322,6 +334,7 @@ async fn run_sync<E: EthSpec + Serialize, S: StateProvider<Spec = E> + Clone>(
             consensus_state.finalized_checkpoint().epoch(),
             state_provider.clone(),
             beacon_client,
+            config_for(network),
         )
         .await?;
 
@@ -331,7 +344,7 @@ async fn run_sync<E: EthSpec + Serialize, S: StateProvider<Spec = E> + Clone>(
             input_bytes,
             network,
             mode,
-            &DEFAULT_CONFIG,
+            config_for(network),
         ) {
             Ok(state) => {
                 info!("Verification successful. New state: {:#?}", &state);
@@ -361,6 +374,7 @@ async fn prepare_input<E: EthSpec + Serialize, S: StateProvider<Spec = E> + Clon
     finalized_epoch: Epoch,
     state_provider: S,
     beacon_client: &BeaconClient,
+    config: &Config,
 ) -> anyhow::Result<(Vec<u8>, ConsensusState, ConsensusState, u64)> {
     let trusted_state = state_provider.state_at_epoch_boundary(finalized_epoch)?;
     let epoch_boundary_slot = trusted_state.latest_block_header().slot;
@@ -387,7 +401,7 @@ async fn prepare_input<E: EthSpec + Serialize, S: StateProvider<Spec = E> + Clon
     info!("Running preflight");
     let reader = PreflightInputReader::new(&reader, beacon_client.clone(), trusted_checkpoint);
     let (post_state, finalized_slot) =
-        verify(&DEFAULT_CONFIG, &reader).context("preflight failed")?;
+        verify(config, &reader).context("preflight failed")?;
     info!("Preflight succeeded");
 
     let input = reader.to_input()?;

--- a/host/src/bin/zkasper_cli.rs
+++ b/host/src/bin/zkasper_cli.rs
@@ -400,8 +400,7 @@ async fn prepare_input<E: EthSpec + Serialize, S: StateProvider<Spec = E> + Clon
 
     info!("Running preflight");
     let reader = PreflightInputReader::new(&reader, beacon_client.clone(), trusted_checkpoint);
-    let (post_state, finalized_slot) =
-        verify(config, &reader).context("preflight failed")?;
+    let (post_state, finalized_slot) = verify(config, &reader).context("preflight failed")?;
     info!("Preflight succeeded");
 
     let input = reader.to_input()?;

--- a/methods/guest/src/bin/sepolia.rs
+++ b/methods/guest/src/bin/sepolia.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/methods/guest/src/bin/sepolia.rs
+++ b/methods/guest/src/bin/sepolia.rs
@@ -14,10 +14,10 @@
 
 #![no_main]
 
-use z_core::{DEFAULT_CONFIG, MainnetEthSpec};
+use z_core::{MainnetEthSpec, SEPOLIA_CONFIG};
 
 risc0_zkvm::guest::entry!(main);
 
 fn main() {
-    beacon_guest::entry::<MainnetEthSpec>(chainspec::sepolia_spec(), &DEFAULT_CONFIG);
+    beacon_guest::entry::<MainnetEthSpec>(chainspec::sepolia_spec(), &SEPOLIA_CONFIG);
 }


### PR DESCRIPTION
Adds a Sepolia-specific `SEPOLIA_CONFIG` with a 70% justification threshold (vs the 85% default) and routes both the host preflight and the Sepolia guest ELF through it. Mainnet paths are unchanged.